### PR TITLE
Add a test hook to allow for tests to manipulate "now" when testing forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openrosa-xpath-evaluator",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Wrapper for browsers' XPath evaluator with added support for OpenRosa extensions.",
   "main": "src/openrosa-xpath.js",
   "scripts": {

--- a/src/openrosa-xpath-extensions.js
+++ b/src/openrosa-xpath-extensions.js
@@ -137,8 +137,16 @@ var openrosa_xpath_extensions = function(translate) {
 
         return sb;
       },
+      _now,
+      overrideNow = function(now) {
+        if (typeof now === 'function') {
+          _now = now();
+        } else {
+          _now = now;
+        }
+      },
       func, process, ret = {},
-      now_and_today = function() { return XPR.date(new Date()); };
+      now_and_today = function() { return XPR.date(_now || new Date()); };
 
   func = {
     'boolean-from-string': function(string) {
@@ -294,6 +302,7 @@ var openrosa_xpath_extensions = function(translate) {
 
   ret.func = func;
   ret.process = process;
+  ret.overrideNow = overrideNow;
 
   return ret;
 };

--- a/src/openrosa-xpath-extensions.js
+++ b/src/openrosa-xpath-extensions.js
@@ -137,16 +137,8 @@ var openrosa_xpath_extensions = function(translate) {
 
         return sb;
       },
-      _now,
-      overrideNow = function(now) {
-        if (typeof now === 'function') {
-          _now = now();
-        } else {
-          _now = now;
-        }
-      },
       func, process, ret = {},
-      now_and_today = function() { return XPR.date(_now || new Date()); };
+      now_and_today = function() { return XPR.date(ret._now()); };
 
   func = {
     'boolean-from-string': function(string) {
@@ -302,7 +294,9 @@ var openrosa_xpath_extensions = function(translate) {
 
   ret.func = func;
   ret.process = process;
-  ret.overrideNow = overrideNow;
+  ret._now = function() { 
+    return new Date();
+  };
 
   return ret;
 };

--- a/test/openrosa-xpath-extensions.spec.js
+++ b/test/openrosa-xpath-extensions.spec.js
@@ -124,6 +124,21 @@ function(or, translate, chai, _) {
       });
     });
 
+    describe('supports overriding current time', () => {
+      _.forEach([
+        new Date('2000-01-01'),
+        () => new Date('2000-01-01'),
+      ], function(v) {
+        it('accepts date override', () => {
+          const extensions = or(translate);
+          extensions.overrideNow(v);
+          const actual = extensions.func.now();
+          assert.equal(actual.t, 'date');
+          assert.include(actual.v.toISOString(), '2000-01-01');
+        });
+      });
+    });
+
     describe('when called with invalid strings', function() {
       _.forEach([
           'nonsense',

--- a/test/openrosa-xpath-extensions.spec.js
+++ b/test/openrosa-xpath-extensions.spec.js
@@ -124,19 +124,12 @@ function(or, translate, chai, _) {
       });
     });
 
-    describe('supports overriding current time', () => {
-      _.forEach([
-        new Date('2000-01-01'),
-        () => new Date('2000-01-01'),
-      ], function(v) {
-        it('accepts date override', () => {
-          const extensions = or(translate);
-          extensions.overrideNow(v);
-          const actual = extensions.func.now();
-          assert.equal(actual.t, 'date');
-          assert.include(actual.v.toISOString(), '2000-01-01');
-        });
-      });
+    it('supports overriding current time', () => {
+      const extensions = or(translate);
+      extensions._now = function() { return new Date('2000-01-01'); };
+      const actual = extensions.func.now();
+      assert.equal(actual.t, 'date');
+      assert.include(actual.v.toISOString(), '2000-01-01');
     });
 
     describe('when called with invalid strings', function() {


### PR DESCRIPTION
https://github.com/medic/medic-conf/issues/128

Adding a test hook so that tests can manipulate the current date for testing xforms. Should have no impact on production (don't even need to pull it into medic/medc package.json).

[This](https://github.com/medic/medic-projects/blob/muso-declarative/muso_declarative/harness/ext/OpenrosaXpathEvaluatorBinding.js#L18) shows how it is wired up into the test harness.

