### PR TITLE
travisci: fix build on medic master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: node_js
 node_js:
-  - "0.12"
+  - "12"
+
+services:
+  - xvfb
 
 before_script:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
 
 script: npm run travis
 


### PR DESCRIPTION
Fixes:
* `xvfb` failing to start
* node version no longer supported