### PR TITLE
orxe2: replace inconsistent tab indentation with spaces

### DIFF
--- a/src/engine.js
+++ b/src/engine.js
@@ -32,71 +32,71 @@ module.exports = (function(){
     XPathEvaluator: OpenrosaXPathEvaluator,
 
     /**
-     * Get the current list of DOM Level 3 XPath window and document objects
-     * that are in use.
-     *
-     * @return {Object} List of DOM Level 3 XPath window and document objects
-     *         that are currently in use.
-     */
-    getCurrentDomLevel3XPathBindings: function()
-    {
-      return {
-        'window': {
-          XPathException: window.XPathException,
-          XPathExpression: window.XPathExpression,
-          XPathNSResolver: window.XPathNSResolver,
-          XPathResult: window.XPathResult,
-          XPathNamespace: window.XPathNamespace
-        },
-        'document': {
-          createExpression: document.createExpression,
-          createNSResolver: document.createNSResolver,
-          evaluate: document.evaluate
-        }
-      };
-    },
+		 * Get the current list of DOM Level 3 XPath window and document objects
+		 * that are in use.
+		 *
+		 * @return {Object} List of DOM Level 3 XPath window and document objects
+		 *         that are currently in use.
+		 */
+		getCurrentDomLevel3XPathBindings: function()
+		{
+			return {
+				'window': {
+					XPathException: window.XPathException,
+					XPathExpression: window.XPathExpression,
+					XPathNSResolver: window.XPathNSResolver,
+					XPathResult: window.XPathResult,
+					XPathNamespace: window.XPathNamespace
+				},
+				'document': {
+					createExpression: document.createExpression,
+					createNSResolver: document.createNSResolver,
+					evaluate: document.evaluate
+				}
+			};
+		},
 
-    /**
-     * Get the list of DOM Level 3 XPath objects that are implemented by
-     * the XPathJS module.
-     *
-     * @return {Object} List of DOM Level 3 XPath objects implemented by
-     *         the XPathJS module.
-     */
-    createDomLevel3XPathBindings: function(options)
-    {
+		/**
+		 * Get the list of DOM Level 3 XPath objects that are implemented by
+		 * the XPathJS module.
+		 *
+		 * @return {Object} List of DOM Level 3 XPath objects implemented by
+		 *         the XPathJS module.
+		 */
+		createDomLevel3XPathBindings: function(options)
+		{
       var openrosaEvaluator = new OpenrosaXPathEvaluator(options);
 
-      return {
-        'document': {
+			return {
+				'document': {
           evaluate: openrosaEvaluator.evaluate
-        }
-      };
-    },
+				}
+			};
+		},
 
-    /**
-     * Bind DOM Level 3 XPath interfaces to the DOM.
-     *
-     * @param {Object} doc the document or (Document.prototype!) to bind the evaluator etc. to
-     * @return List of original DOM Level 3 XPath objects that has been replaced
-     */
-    bindDomLevel3XPath: function(doc, bindings)
-    {
-      var newBindings = (bindings || module.createDomLevel3XPathBindings()),
-        currentBindings = module.getCurrentDomLevel3XPathBindings(),
-        i
-      ;
+		/**
+		 * Bind DOM Level 3 XPath interfaces to the DOM.
+		 *
+		 * @param {Object} doc the document or (Document.prototype!) to bind the evaluator etc. to
+		 * @return List of original DOM Level 3 XPath objects that has been replaced
+		 */
+		bindDomLevel3XPath: function(doc, bindings)
+		{
+			var newBindings = (bindings || module.createDomLevel3XPathBindings()),
+				currentBindings = module.getCurrentDomLevel3XPathBindings(),
+				i
+			;
 
-      doc = doc || document;
+			doc = doc || document;
 
-      for(i in newBindings['document'])
-      {
-        doc[i] = newBindings['document'][i];
-      }
+			for(i in newBindings['document'])
+			{
+				doc[i] = newBindings['document'][i];
+			}
 
-      return currentBindings;
-    }
+			return currentBindings;
+		}
   };
-  return module;
+	return module;
 
 })();

--- a/src/engine.js
+++ b/src/engine.js
@@ -32,71 +32,71 @@ module.exports = (function(){
     XPathEvaluator: OpenrosaXPathEvaluator,
 
     /**
-		 * Get the current list of DOM Level 3 XPath window and document objects
-		 * that are in use.
-		 *
-		 * @return {Object} List of DOM Level 3 XPath window and document objects
-		 *         that are currently in use.
-		 */
-		getCurrentDomLevel3XPathBindings: function()
-		{
-			return {
-				'window': {
-					XPathException: window.XPathException,
-					XPathExpression: window.XPathExpression,
-					XPathNSResolver: window.XPathNSResolver,
-					XPathResult: window.XPathResult,
-					XPathNamespace: window.XPathNamespace
-				},
-				'document': {
-					createExpression: document.createExpression,
-					createNSResolver: document.createNSResolver,
-					evaluate: document.evaluate
-				}
-			};
-		},
+     * Get the current list of DOM Level 3 XPath window and document objects
+     * that are in use.
+     *
+     * @return {Object} List of DOM Level 3 XPath window and document objects
+     *         that are currently in use.
+     */
+    getCurrentDomLevel3XPathBindings: function()
+    {
+      return {
+        'window': {
+          XPathException: window.XPathException,
+          XPathExpression: window.XPathExpression,
+          XPathNSResolver: window.XPathNSResolver,
+          XPathResult: window.XPathResult,
+          XPathNamespace: window.XPathNamespace
+        },
+        'document': {
+          createExpression: document.createExpression,
+          createNSResolver: document.createNSResolver,
+          evaluate: document.evaluate
+        }
+      };
+    },
 
-		/**
-		 * Get the list of DOM Level 3 XPath objects that are implemented by
-		 * the XPathJS module.
-		 *
-		 * @return {Object} List of DOM Level 3 XPath objects implemented by
-		 *         the XPathJS module.
-		 */
-		createDomLevel3XPathBindings: function(options)
-		{
+    /**
+     * Get the list of DOM Level 3 XPath objects that are implemented by
+     * the XPathJS module.
+     *
+     * @return {Object} List of DOM Level 3 XPath objects implemented by
+     *         the XPathJS module.
+     */
+    createDomLevel3XPathBindings: function(options)
+    {
       var openrosaEvaluator = new OpenrosaXPathEvaluator(options);
 
-			return {
-				'document': {
+      return {
+        'document': {
           evaluate: openrosaEvaluator.evaluate
-				}
-			};
-		},
+        }
+      };
+    },
 
-		/**
-		 * Bind DOM Level 3 XPath interfaces to the DOM.
-		 *
-		 * @param {Object} doc the document or (Document.prototype!) to bind the evaluator etc. to
-		 * @return List of original DOM Level 3 XPath objects that has been replaced
-		 */
-		bindDomLevel3XPath: function(doc, bindings)
-		{
-			var newBindings = (bindings || module.createDomLevel3XPathBindings()),
-				currentBindings = module.getCurrentDomLevel3XPathBindings(),
-				i
-			;
+    /**
+     * Bind DOM Level 3 XPath interfaces to the DOM.
+     *
+     * @param {Object} doc the document or (Document.prototype!) to bind the evaluator etc. to
+     * @return List of original DOM Level 3 XPath objects that has been replaced
+     */
+    bindDomLevel3XPath: function(doc, bindings)
+    {
+      var newBindings = (bindings || module.createDomLevel3XPathBindings()),
+        currentBindings = module.getCurrentDomLevel3XPathBindings(),
+        i
+      ;
 
-			doc = doc || document;
+      doc = doc || document;
 
-			for(i in newBindings['document'])
-			{
-				doc[i] = newBindings['document'][i];
-			}
+      for(i in newBindings['document'])
+      {
+        doc[i] = newBindings['document'][i];
+      }
 
-			return currentBindings;
-		}
+      return currentBindings;
+    }
   };
-	return module;
+  return module;
 
 })();

--- a/src/openrosa-extensions.js
+++ b/src/openrosa-extensions.js
@@ -191,7 +191,7 @@ var openrosa_xpath_extensions = function(config) {
     area: function(r) {
       if(arguments.length === 0) throw TOO_FEW_ARGS;
       return areaOrDistance(XPR.number, area, r);
-		},
+    },
     checklist: function(min, max) {
       var i, j, trues = 0;
       min = min.v;
@@ -251,7 +251,7 @@ var openrosa_xpath_extensions = function(config) {
       var time = r.v;
       // There is no Time type, and so far we don't need it so we do all validation
       // and conversion here, manually.
-      var	m = time.match(/^(\d\d):(\d\d):(\d\d)(\.\d\d?\d?)?(\+|-)(\d\d):(\d\d)$/);
+      var  m = time.match(/^(\d\d):(\d\d):(\d\d)(\.\d\d?\d?)?(\+|-)(\d\d):(\d\d)$/);
       var dec;
       if (m &&
         m[1] < 24 && m[1] >= 0 &&

--- a/src/random-token.js
+++ b/src/random-token.js
@@ -3,8 +3,8 @@ function _random13chars() {
 }
 
 function randomToken(length) {
-	var loops = Math.ceil(length / 13);
-	return new Array(loops)
+  var loops = Math.ceil(length / 13);
+  return new Array(loops)
     .fill(_random13chars)
     .reduce((string, func) => {
       return string + func();

--- a/src/utils/shuffle.js
+++ b/src/utils/shuffle.js
@@ -42,9 +42,9 @@ function shuffle(array, seed) {
  */
 function Random(seed) {
     this._seed = seed % MAX_INT32;
-	if(this._seed <= 0) {
-		this._seed += (MAX_INT32 - 1);
-	}
+  if(this._seed <= 0) {
+    this._seed += (MAX_INT32 - 1);
+  }
 }
 
 /**

--- a/test/integration/native/axis.spec.js
+++ b/test/integration/native/axis.spec.js
@@ -11,65 +11,65 @@ describe('axes', () => {
       <!DOCTYPE html>
       <html xml:lang="en-us" xmlns="http://www.w3.org/1999/xhtml" xmlns:ev="http://some-namespace.com/nss">
         <head>
-      		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-      		<title>xpath-test</title>
-      	</head>
-      	<body class="yui3-skin-sam" id="body">
+          <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+          <title>xpath-test</title>
+        </head>
+        <body class="yui3-skin-sam" id="body">
           <div id="StepAxisCase">
 
-      			<div id="testStepAxisNodeElement"></div>
-      			<div id="testStepAxisNodeAttribute" style="sss:asdf;" width="100%"></div>
-      			<div id="testStepAxisNodeCData"><![CDATA[aa<strong>some text</strong>]]><div></div>asdf</div>
-      			<div id="testStepAxisNodeComment"><!-- here is comment --><div></div>asdf</div>
-      			<div id="testStepAxisNodeProcessingInstruction"><?xml-stylesheet type="text/xml" href="test.xsl"?><div></div>asdf</div>
-      			<div id="testStepAxisNodeNamespace" xmlns:asdf="http://some-namespace/" width="100%"></div>
+            <div id="testStepAxisNodeElement"></div>
+            <div id="testStepAxisNodeAttribute" style="sss:asdf;" width="100%"></div>
+            <div id="testStepAxisNodeCData"><![CDATA[aa<strong>some text</strong>]]><div></div>asdf</div>
+            <div id="testStepAxisNodeComment"><!-- here is comment --><div></div>asdf</div>
+            <div id="testStepAxisNodeProcessingInstruction"><?xml-stylesheet type="text/xml" href="test.xsl"?><div></div>asdf</div>
+            <div id="testStepAxisNodeNamespace" xmlns:asdf="http://some-namespace/" width="100%"></div>
 
-      			<div id="testStepAxisChild">
-      				some text
-      				<![CDATA[aa<strong>some text</strong>]]>
-      				<div></div>
-      				<div></div>
-      				<div></div>
-      				<div></div>
-      				<div></div>
-      			</div>
+            <div id="testStepAxisChild">
+              some text
+              <![CDATA[aa<strong>some text</strong>]]>
+              <div></div>
+              <div></div>
+              <div></div>
+              <div></div>
+              <div></div>
+            </div>
 
-      			<div id="testStepAxisDescendant">
-      				<div>
-      					<div></div>
-      					<div></div>
-      					<div></div>
-      					<div>
-      						<div></div>
-      						<div></div>
-      						<!-- here is comment -->
-      					</div>
-      				</div>
-      				<div></div>
-      			</div>
+            <div id="testStepAxisDescendant">
+              <div>
+                <div></div>
+                <div></div>
+                <div></div>
+                <div>
+                  <div></div>
+                  <div></div>
+                  <!-- here is comment -->
+                </div>
+              </div>
+              <div></div>
+            </div>
 
-      			<div id="testStepAxisAttribute">
-      				<div id="testStepAxisNodeAttribute0"></div>
-      				<div id="testStepAxisNodeAttribute1" class="test 123"></div>
-      				<div id="testStepAxisNodeAttribute3" style="aaa" class="test 123" width="100%"></div>
-      				<div id="testStepAxisNodeAttributeStartXml" xmlnswidth="100%" xml="sss"></div>
+            <div id="testStepAxisAttribute">
+              <div id="testStepAxisNodeAttribute0"></div>
+              <div id="testStepAxisNodeAttribute1" class="test 123"></div>
+              <div id="testStepAxisNodeAttribute3" style="aaa" class="test 123" width="100%"></div>
+              <div id="testStepAxisNodeAttributeStartXml" xmlnswidth="100%" xml="sss"></div>
 
-      				<div id="testStepAxisNodeNamespace0"></div>
-      				<div id="testStepAxisNodeNamespace1" xmlns:a="asdf"></div>
-      				<div id="testStepAxisNodeNamespace1b" xmlns:a="asdf"></div>
-      				<div id="testStepAxisNodeNamespace1defaultContainer"><div xmlns="asdf"></div></div>
-      				<div id="testStepAxisNodeNamespace1defaultContainer2"><div xmlns=""></div></div>
-      				<div id="testStepAxisNodeNamespace3" xmlns:a="asdf" xmlns:b="asdf2" xmlns:c="asdf3"></div>
-      				<div id="testStepAxisNodeNamespace3defaultContainer"><div xmlns:a="asdf" xmlns="asdf2" xmlns:c="asdf3"></div></div>
-      				<div id="testStepAxisNodeNamespaceXmlOverride" xmlns:ev="http://some-other-namespace/"></div>
+              <div id="testStepAxisNodeNamespace0"></div>
+              <div id="testStepAxisNodeNamespace1" xmlns:a="asdf"></div>
+              <div id="testStepAxisNodeNamespace1b" xmlns:a="asdf"></div>
+              <div id="testStepAxisNodeNamespace1defaultContainer"><div xmlns="asdf"></div></div>
+              <div id="testStepAxisNodeNamespace1defaultContainer2"><div xmlns=""></div></div>
+              <div id="testStepAxisNodeNamespace3" xmlns:a="asdf" xmlns:b="asdf2" xmlns:c="asdf3"></div>
+              <div id="testStepAxisNodeNamespace3defaultContainer"><div xmlns:a="asdf" xmlns="asdf2" xmlns:c="asdf3"></div></div>
+              <div id="testStepAxisNodeNamespaceXmlOverride" xmlns:ev="http://some-other-namespace/"></div>
 
-      				<div id="testStepAxisNodeAttrib1Ns1" class="test 123" xmlns:a="asdf"></div>
-      				<div id="testStepAxisNodeAttrib1Ns1reversed" xmlns:a="asdf" class="test 123"></div>
-      				<div id="testStepAxisNodeAttrib2Ns1" style="aaa" class="test 123" xmlns:c="asdf3"></div>
-      				<div id="testStepAxisNodeAttrib2Ns1reversedContainer"><div style="aaa" xmlns="asdf" class="test 123"></div></div>
-      				<div id="testStepAxisNodeAttrib2Ns2Container"><div xmlns:a="asdf" xmlns="asdf2" style="aaa" class="test 123"></div></div>
-      			</div>
-      		</div>
+              <div id="testStepAxisNodeAttrib1Ns1" class="test 123" xmlns:a="asdf"></div>
+              <div id="testStepAxisNodeAttrib1Ns1reversed" xmlns:a="asdf" class="test 123"></div>
+              <div id="testStepAxisNodeAttrib2Ns1" style="aaa" class="test 123" xmlns:c="asdf3"></div>
+              <div id="testStepAxisNodeAttrib2Ns1reversedContainer"><div style="aaa" xmlns="asdf" class="test 123"></div></div>
+              <div id="testStepAxisNodeAttrib2Ns2Container"><div xmlns:a="asdf" xmlns="asdf2" style="aaa" class="test 123"></div></div>
+            </div>
+          </div>
         </body>
       </html>`, nsResolver);
 

--- a/test/integration/native/boolean.spec.js
+++ b/test/integration/native/boolean.spec.js
@@ -25,10 +25,10 @@ describe('native boolean functions', () => {
       <!DOCTYPE html>
       <html xml:lang="en-us" xmlns="http://www.w3.org/1999/xhtml" xmlns:ev="http://some-namespace.com/nss">
         <head>
-      		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-      		<title>xpath-test</title>
-      	</head>
-      	<body class="yui3-skin-sam" id="body">
+          <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+          <title>xpath-test</title>
+        </head>
+        <body class="yui3-skin-sam" id="body">
         </body>
       </html>`, nsResolver);
     assertTrue("boolean(/xhtml:html)");

--- a/test/integration/native/comparison-operator.spec.js
+++ b/test/integration/native/comparison-operator.spec.js
@@ -97,18 +97,18 @@ describe('Comparison operator', () => {
       doc = initDoc(`
         <div id="ComparisonOperatorCase">
           <div id="ComparisonOperatorCaseNodesetNegative5to5">
-    				<div>-5</div>
-    				<div>-4</div>
-    				<div>-3</div>
-    				<div>-2</div>
-    				<div>-1</div>
-    				<div>0</div>
-    				<div>1</div>
-    				<div>2</div>
-    				<div>3</div>
-    				<div>4</div>
-    				<div>5</div>
-    			</div>
+            <div>-5</div>
+            <div>-4</div>
+            <div>-3</div>
+            <div>-2</div>
+            <div>-1</div>
+            <div>0</div>
+            <div>1</div>
+            <div>2</div>
+            <div>3</div>
+            <div>4</div>
+            <div>5</div>
+          </div>
           <div id="ComparisonOperatorCaseNodesetEmpty">
           </div>
           <div id="ComparisonOperatorCaseNodesetStrings">

--- a/test/integration/native/comparison-operator2.spec.js
+++ b/test/integration/native/comparison-operator2.spec.js
@@ -5,47 +5,47 @@ describe('Comparison operator', () => {
   beforeEach(() => {
     doc = initDoc(`
       <div id="ComparisonOperatorCase">
-  			<div id="ComparisonOperatorCaseNodesetNegative5to5">
-  				<div>-5</div>
-  				<div>-4</div>
-  				<div>-3</div>
-  				<div>-2</div>
-  				<div>-1</div>
-  				<div>0</div>
-  				<div>1</div>
-  				<div>2</div>
-  				<div>3</div>
-  				<div>4</div>
-  				<div>5</div>
-  			</div>
+        <div id="ComparisonOperatorCaseNodesetNegative5to5">
+          <div>-5</div>
+          <div>-4</div>
+          <div>-3</div>
+          <div>-2</div>
+          <div>-1</div>
+          <div>0</div>
+          <div>1</div>
+          <div>2</div>
+          <div>3</div>
+          <div>4</div>
+          <div>5</div>
+        </div>
 
-  			<div id="ComparisonOperatorCaseNodeset6to10">
-  				<div>6</div>
-  				<div>7</div>
-  				<div>8</div>
-  				<div>9</div>
-  				<div>10</div>
-  			</div>
+        <div id="ComparisonOperatorCaseNodeset6to10">
+          <div>6</div>
+          <div>7</div>
+          <div>8</div>
+          <div>9</div>
+          <div>10</div>
+        </div>
 
-  			<div id="ComparisonOperatorCaseNodeset4to8">
-  				<div>4</div>
-  				<div>5</div>
-  				<div>6</div>
-  				<div>7</div>
-  				<div>8</div>
-  			</div>
+        <div id="ComparisonOperatorCaseNodeset4to8">
+          <div>4</div>
+          <div>5</div>
+          <div>6</div>
+          <div>7</div>
+          <div>8</div>
+        </div>
 
-  			<div id="ComparisonOperatorCaseNodesetEmpty">
-  			</div>
+        <div id="ComparisonOperatorCaseNodesetEmpty">
+        </div>
 
-  			<div id="ComparisonOperatorCaseNodesetStrings">
-  				<div>aaa</div>
-  				<div>bbb</div>
-  				<div>cccccc</div>
-  				<div>ddd</div>
-  				<div>eee</div>
-  			</div>
-  		</div>
+        <div id="ComparisonOperatorCaseNodesetStrings">
+          <div>aaa</div>
+          <div>bbb</div>
+          <div>cccccc</div>
+          <div>ddd</div>
+          <div>eee</div>
+        </div>
+      </div>
       `);
   });
 
@@ -161,47 +161,47 @@ describe('Comparison operator', () => {
     beforeEach(() => {
       doc = initDoc(`
         <div id="ComparisonOperatorCase">
-    			<div id="ComparisonOperatorCaseNodesetNegative5to5">
-    				<div>-5</div>
-    				<div>-4</div>
-    				<div>-3</div>
-    				<div>-2</div>
-    				<div>-1</div>
-    				<div>0</div>
-    				<div>1</div>
-    				<div>2</div>
-    				<div>3</div>
-    				<div>4</div>
-    				<div>5</div>
-    			</div>
+          <div id="ComparisonOperatorCaseNodesetNegative5to5">
+            <div>-5</div>
+            <div>-4</div>
+            <div>-3</div>
+            <div>-2</div>
+            <div>-1</div>
+            <div>0</div>
+            <div>1</div>
+            <div>2</div>
+            <div>3</div>
+            <div>4</div>
+            <div>5</div>
+          </div>
 
-    			<div id="ComparisonOperatorCaseNodeset6to10">
-    				<div>6</div>
-    				<div>7</div>
-    				<div>8</div>
-    				<div>9</div>
-    				<div>10</div>
-    			</div>
+          <div id="ComparisonOperatorCaseNodeset6to10">
+            <div>6</div>
+            <div>7</div>
+            <div>8</div>
+            <div>9</div>
+            <div>10</div>
+          </div>
 
-    			<div id="ComparisonOperatorCaseNodeset4to8">
-    				<div>4</div>
-    				<div>5</div>
-    				<div>6</div>
-    				<div>7</div>
-    				<div>8</div>
-    			</div>
+          <div id="ComparisonOperatorCaseNodeset4to8">
+            <div>4</div>
+            <div>5</div>
+            <div>6</div>
+            <div>7</div>
+            <div>8</div>
+          </div>
 
-    			<div id="ComparisonOperatorCaseNodesetEmpty">
-    			</div>
+          <div id="ComparisonOperatorCaseNodesetEmpty">
+          </div>
 
-    			<div id="ComparisonOperatorCaseNodesetStrings">
-    				<div>aaa</div>
-    				<div>bbb</div>
-    				<div>cccccc</div>
-    				<div>ddd</div>
-    				<div>eee</div>
-    			</div>
-    		</div>
+          <div id="ComparisonOperatorCaseNodesetStrings">
+            <div>aaa</div>
+            <div>bbb</div>
+            <div>cccccc</div>
+            <div>ddd</div>
+            <div>eee</div>
+          </div>
+        </div>
       `);
     });
 

--- a/test/integration/native/expression-evaluation.spec.js
+++ b/test/integration/native/expression-evaluation.spec.js
@@ -12,14 +12,14 @@ describe('XPath expression evaluation', () => {
         </head>
         <body class="yui3-skin-sam" id="body">
           <div id="XPathExpressionEvaluateCase">
-      			<div id="testContextNodeParameter" style="display:block;">
-      				<div id="testContextNodeParameterText">some text</div>
-      				<div id="testContextNodeParameterCData"><![CDATA[aa<strong>some text</strong>]]></div>
-      				<div id="testContextNodeParameterComment"><!-- here is comment --></div>
-      				<div id="testContextNodeParameterProcessingInstruction"><?xml-stylesheet type="text/xml" href="test.xsl"?></div>
-      				<div id="testContextNodeParameterNamespace" xmlns:asdf="http://some-namespace/"></div>
-      			</div>
-  		    </div>
+            <div id="testContextNodeParameter" style="display:block;">
+              <div id="testContextNodeParameterText">some text</div>
+              <div id="testContextNodeParameterCData"><![CDATA[aa<strong>some text</strong>]]></div>
+              <div id="testContextNodeParameterComment"><!-- here is comment --></div>
+              <div id="testContextNodeParameterProcessingInstruction"><?xml-stylesheet type="text/xml" href="test.xsl"?></div>
+              <div id="testContextNodeParameterNamespace" xmlns:asdf="http://some-namespace/"></div>
+            </div>
+          </div>
         </body>
       </html>`);
   });

--- a/test/integration/native/namespace-resolver.spec.js
+++ b/test/integration/native/namespace-resolver.spec.js
@@ -12,22 +12,22 @@ describe('namespace resolver', () => {
         </head>
         <body class="yui3-skin-sam" id="body">
           <div id="testXPathNSResolver">
-      			<div id="testXPathNSResolverNode" xmlns:xforms="http://www.w3.org/2002/xforms">
-      				<div xmlns="http://www.w3.org/TR/REC-html40">
-      					<div></div>
-      				</div>
-      				<xforms:model>
-      				  <xforms:instance>
-      				    <ecommerce xmlns="">
-      				      <method></method>
-      				      <number></number>
-      				      <expiry></expiry>
-      				    </ecommerce>
-      				  </xforms:instance>
-      				  <xforms:submission action="http://example.com/submit" method="post" id="submit" includenamespaceprefixes=""/>
-      				</xforms:model>
-      			</div>
-  		    </div>
+            <div id="testXPathNSResolverNode" xmlns:xforms="http://www.w3.org/2002/xforms">
+              <div xmlns="http://www.w3.org/TR/REC-html40">
+                <div></div>
+              </div>
+              <xforms:model>
+                <xforms:instance>
+                  <ecommerce xmlns="">
+                    <method></method>
+                    <number></number>
+                    <expiry></expiry>
+                  </ecommerce>
+                </xforms:instance>
+                <xforms:submission action="http://example.com/submit" method="post" id="submit" includenamespaceprefixes=""/>
+              </xforms:model>
+            </div>
+          </div>
         </body>
       </html>`);
   });

--- a/test/integration/native/node-name.spec.js
+++ b/test/integration/native/node-name.spec.js
@@ -16,28 +16,28 @@ describe('node name for', () => {
         </head>
         <body class="yui3-skin-sam" id="body">
           <div id="StepNodeTestCaseNameTest">
-      			<div id="StepNodeTestCaseNameTestAttribute" ev:attrib1="value" ev:attrib2="value2" xml:attrib2="something" xml:sss="something2" attrib3="asdf" xmlns:ns2="http://asdf/" ns2:attrib4="Hello world"></div>
-      			<div id="StepNodeTestCaseNameTestNamespace" xmlns:ns1="test-123" xmlns:ns2="http://asdf/" ev:attrib1="value" xml:attrib2="something" attrib3="asdf"></div>
-      			<div id="StepNodeTestCaseNameTestChild"><div xmlns="http://asdf/"></div><ev:div xmlns:ev="http://asdf/"></ev:div><ev:span xmlns:ev="http://asdf/"></ev:span>
-      				<div></div>
-      				asdf
-      				<!-- asdf -->
-      				asdf
-      				<div></div>
+            <div id="StepNodeTestCaseNameTestAttribute" ev:attrib1="value" ev:attrib2="value2" xml:attrib2="something" xml:sss="something2" attrib3="asdf" xmlns:ns2="http://asdf/" ns2:attrib4="Hello world"></div>
+            <div id="StepNodeTestCaseNameTestNamespace" xmlns:ns1="test-123" xmlns:ns2="http://asdf/" ev:attrib1="value" xml:attrib2="something" attrib3="asdf"></div>
+            <div id="StepNodeTestCaseNameTestChild"><div xmlns="http://asdf/"></div><ev:div xmlns:ev="http://asdf/"></ev:div><ev:span xmlns:ev="http://asdf/"></ev:span>
+              <div></div>
+              asdf
+              <!-- asdf -->
+              asdf
+              <div></div>
 
-      				<div></div>
-      				asas
-      				<div></div>
-      			</div>
+              <div></div>
+              asas
+              <div></div>
+            </div>
 
-      			<div id="StepNodeTestCaseNameTest1">
-      				<div id="StepNodeTestCaseNameTest2">
-      					<div id="StepNodeTestCaseNameTest3"></div>
-      				</div>
-      			</div>
+            <div id="StepNodeTestCaseNameTest1">
+              <div id="StepNodeTestCaseNameTest2">
+                <div id="StepNodeTestCaseNameTest3"></div>
+              </div>
+            </div>
 
-      			<div id="StepNodeTestCaseNameTestNoNamespace"><div xmlns=""><div><div></div></div></div></div>
-  		    </div>
+            <div id="StepNodeTestCaseNameTestNoNamespace"><div xmlns=""><div><div></div></div></div></div>
+          </div>
         </body>
       </html>`, nsResolver);
 

--- a/test/integration/native/node-type.spec.js
+++ b/test/integration/native/node-type.spec.js
@@ -5,24 +5,24 @@ describe('node-type', () => {
   beforeEach(() => {
     doc = initDoc(`
       <div id="StepNodeTestNodeTypeCase">
-  			some text
-  			<div></div>
-  			<div>
-  				<div></div>
-  			</div>
-  			<!-- comment --><!-- comment -->
-  			asdf
-  			asdfsdf sdf
-  			<div></div>
-  			<?xml-stylesheet type="text/xml" href="test.xsl"?>
-  			<div></div>
-  			sdfsdf
-  			<![CDATA[aa<strong>some text</strong>]]>
-  			<!-- comment -->
-  			<div></div>
-  			<?custom-process-instruct type="text/xml" href="test.xsl"?>
-  			<div></div>
-  		</div>`);
+        some text
+        <div></div>
+        <div>
+          <div></div>
+        </div>
+        <!-- comment --><!-- comment -->
+        asdf
+        asdfsdf sdf
+        <div></div>
+        <?xml-stylesheet type="text/xml" href="test.xsl"?>
+        <div></div>
+        sdfsdf
+        <![CDATA[aa<strong>some text</strong>]]>
+        <!-- comment -->
+        <div></div>
+        <?custom-process-instruct type="text/xml" href="test.xsl"?>
+        <div></div>
+      </div>`);
   });
 
   it('"node" is supported', () => {

--- a/test/integration/native/nodeset-id.spec.js
+++ b/test/integration/native/nodeset-id.spec.js
@@ -6,22 +6,22 @@ describe('nodeset id() function', () => {
   beforeEach(() => {
     doc = initDoc(`
       <div id="FunctionNodesetIdCase">
-  			<div id="FunctionNodesetIdCaseSimple"></div>
-  			<div id="FunctionNodesetIdCaseNoDefaultNamespaceContainer"><div id="FunctionNodesetIdCaseNoDefaultNamespace" xmlns=""></div></div>
-  			<div id="FunctionNodesetIdCaseXhtmlDefaultNamespaceContainer"><div id="FunctionNodesetIdCaseXhtmlDefaultNamespace" xmlns="http://www.w3.org/1999/xhtml"></div></div>
-  			<div id="FunctionNodesetIdCaseXhtmlNamespaceContainer"><div xhtml:id="FunctionNodesetIdCaseXhtmlNamespace" xmlns:xhtml="http://www.w3.org/1999/xhtml"></div></div>
-  			<div id="FunctionNodesetIdCaseXhtmlNamespaceParentContainer" xmlns:xhtml="http://www.w3.org/1999/xhtml"><div xhtml:id="FunctionNodesetIdCaseXhtmlNamespaceParent"></div></div>
-  			<div id="FunctionNodesetIdXmlNamespaceContainer"><div xml:id="FunctionNodesetIdXmlNamespace" xmlns=""></div></div>
+        <div id="FunctionNodesetIdCaseSimple"></div>
+        <div id="FunctionNodesetIdCaseNoDefaultNamespaceContainer"><div id="FunctionNodesetIdCaseNoDefaultNamespace" xmlns=""></div></div>
+        <div id="FunctionNodesetIdCaseXhtmlDefaultNamespaceContainer"><div id="FunctionNodesetIdCaseXhtmlDefaultNamespace" xmlns="http://www.w3.org/1999/xhtml"></div></div>
+        <div id="FunctionNodesetIdCaseXhtmlNamespaceContainer"><div xhtml:id="FunctionNodesetIdCaseXhtmlNamespace" xmlns:xhtml="http://www.w3.org/1999/xhtml"></div></div>
+        <div id="FunctionNodesetIdCaseXhtmlNamespaceParentContainer" xmlns:xhtml="http://www.w3.org/1999/xhtml"><div xhtml:id="FunctionNodesetIdCaseXhtmlNamespaceParent"></div></div>
+        <div id="FunctionNodesetIdXmlNamespaceContainer"><div xml:id="FunctionNodesetIdXmlNamespace" xmlns=""></div></div>
 
-  			<div>
-  				<div id="FunctionNodesetIdCaseMultiple1"></div>
-  				<div id="FunctionNodesetIdCaseMultiple2"></div>
-  				<div id="FunctionNodesetIdCaseMultiple3"></div>
-  				<div id="FunctionNodesetIdCaseMultiple4"></div>
-  			</div>
+        <div>
+          <div id="FunctionNodesetIdCaseMultiple1"></div>
+          <div id="FunctionNodesetIdCaseMultiple2"></div>
+          <div id="FunctionNodesetIdCaseMultiple3"></div>
+          <div id="FunctionNodesetIdCaseMultiple4"></div>
+        </div>
 
-  			<div id="FunctionNodesetIdCaseNodeset"><p>FunctionNodesetIdCaseMultiple2</p><p>FunctionNodesetIdCaseMultiple1</p><p>FunctionNodesetIdCaseMultiple2 FunctionNodesetIdCaseMultiple4</p><p>FunctionNodesetIdCaseMultiple3</p></div>
-  		</div>`);
+        <div id="FunctionNodesetIdCaseNodeset"><p>FunctionNodesetIdCaseMultiple2</p><p>FunctionNodesetIdCaseMultiple1</p><p>FunctionNodesetIdCaseMultiple2 FunctionNodesetIdCaseMultiple4</p><p>FunctionNodesetIdCaseMultiple3</p></div>
+      </div>`);
   });
 
   it('works for a simple case', () => {

--- a/test/integration/native/nodeset.spec.js
+++ b/test/integration/native/nodeset.spec.js
@@ -7,19 +7,19 @@ describe('native nodeset functions', () => {
     const doc = initDoc(`
       <!DOCTYPE html>
       <html xml:lang="en-us" xmlns="http://www.w3.org/1999/xhtml" xmlns:ev="http://some-namespace.com/nss">
-      	<head>
-      		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-      		<title>xpath-test</title>
-      	</head>
-      	<body class="yui3-skin-sam" id="body">
+        <head>
+          <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+          <title>xpath-test</title>
+        </head>
+        <body class="yui3-skin-sam" id="body">
           <div id="testFunctionNodeset">
-      			<div id="testFunctionNodeset2">
-      				<p>1</p>
-      				<p>2</p>
-      				<p>3</p>
-      				<p>4</p>
-      			</div>
-      		</div>
+            <div id="testFunctionNodeset2">
+              <p>1</p>
+              <p>2</p>
+              <p>3</p>
+              <p>4</p>
+            </div>
+          </div>
         </body>
       </html>`, nsResolver);
     const node = doc.getElementById('testFunctionNodeset2');
@@ -40,19 +40,19 @@ describe('native nodeset functions', () => {
     const doc = initDoc(`
       <!DOCTYPE html>
       <html xml:lang="en-us" xmlns="http://www.w3.org/1999/xhtml" xmlns:ev="http://some-namespace.com/nss">
-      	<head>
-      		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-      		<title>xpath-test</title>
-      	</head>
-      	<body class="yui3-skin-sam" id="body">
+        <head>
+          <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+          <title>xpath-test</title>
+        </head>
+        <body class="yui3-skin-sam" id="body">
           <div id="testFunctionNodeset">
-      			<div id="testFunctionNodeset2">
-      				<p>1</p>
-      				<p>2</p>
-      				<p>3</p>
-      				<p>4</p>
-      			</div>
-      		</div>
+            <div id="testFunctionNodeset2">
+              <p>1</p>
+              <p>2</p>
+              <p>3</p>
+              <p>4</p>
+            </div>
+          </div>
         </body>
       </html>`, nsResolver);
     const node = doc.getElementById('testFunctionNodeset2');
@@ -80,19 +80,19 @@ describe('native nodeset functions', () => {
     const doc = initDoc(`
       <!DOCTYPE html>
       <html xml:lang="en-us" xmlns="http://www.w3.org/1999/xhtml" xmlns:ev="http://some-namespace.com/nss">
-      	<head>
-      		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-      		<title>xpath-test</title>
-      	</head>
-      	<body class="yui3-skin-sam" id="body">
+        <head>
+          <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+          <title>xpath-test</title>
+        </head>
+        <body class="yui3-skin-sam" id="body">
           <div id="testFunctionNodeset">
-      			<div id="testFunctionNodeset2">
-      				<p>1</p>
-      				<p>2</p>
-      				<p>3</p>
-      				<p>4</p>
-      			</div>
-      		</div>
+            <div id="testFunctionNodeset2">
+              <p>1</p>
+              <p>2</p>
+              <p>3</p>
+              <p>4</p>
+            </div>
+          </div>
         </body>
       </html>`, nsResolver);
     const node = doc.getElementById('testFunctionNodeset2');
@@ -121,22 +121,22 @@ describe('native nodeset functions', () => {
     const doc = initDoc(`
       <!DOCTYPE html>
       <html xml:lang="en-us" xmlns="http://www.w3.org/1999/xhtml" xmlns:ev="http://some-namespace.com/nss">
-      	<head>
-      		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-      		<title>xpath-test</title>
-      	</head>
-      	<body class="yui3-skin-sam" id="body">
+        <head>
+          <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+          <title>xpath-test</title>
+        </head>
+        <body class="yui3-skin-sam" id="body">
           <div id="testFunctionNodeset">
-      			<div id="testFunctionNodesetElement">aaa</div>
-      			<div id="testFunctionNodesetElementPrefix"><ev:div2></ev:div2></div>
-      			<div id="testFunctionNodesetElementNested"><span>bbb</span>sss<span></span><div>ccc<span>ddd</span></div></div>
-      			<div id="testFunctionNodesetComment"><!-- hello world --></div>
-      			<div id="testFunctionNodesetText">here is some text</div>
-      			<div id="testFunctionNodesetProcessingInstruction"><?xml-stylesheet type="text/xml" href="test.xsl"?></div>
-      			<div id="testFunctionNodesetCData"><![CDATA[some cdata]]></div>
-      			<div id="testFunctionNodesetAttribute" ev:class="123" width="  1   00%  "></div>
-      			<div id="testFunctionNodesetNamespace" xmlns:asdf="http://www.123.com/"></div>
-      		</div>
+            <div id="testFunctionNodesetElement">aaa</div>
+            <div id="testFunctionNodesetElementPrefix"><ev:div2></ev:div2></div>
+            <div id="testFunctionNodesetElementNested"><span>bbb</span>sss<span></span><div>ccc<span>ddd</span></div></div>
+            <div id="testFunctionNodesetComment"><!-- hello world --></div>
+            <div id="testFunctionNodesetText">here is some text</div>
+            <div id="testFunctionNodesetProcessingInstruction"><?xml-stylesheet type="text/xml" href="test.xsl"?></div>
+            <div id="testFunctionNodesetCData"><![CDATA[some cdata]]></div>
+            <div id="testFunctionNodesetAttribute" ev:class="123" width="  1   00%  "></div>
+            <div id="testFunctionNodesetNamespace" xmlns:asdf="http://www.123.com/"></div>
+          </div>
         </body>
       </html>`, nsResolver);
     let result;
@@ -191,11 +191,11 @@ describe('native nodeset functions', () => {
     const doc = initDoc(`
       <!DOCTYPE html>
       <html xml:lang="en-us" xmlns="http://www.w3.org/1999/xhtml" xmlns:ev="http://some-namespace.com/nss">
-      	<head>
-      		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-      		<title>xpath-test</title>
-      	</head>
-      	<body class="yui3-skin-sam" id="body">
+        <head>
+          <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+          <title>xpath-test</title>
+        </head>
+        <body class="yui3-skin-sam" id="body">
           <div id="testFunctionNodesetNamespace" xmlns:asdf="http://www.123.com/"></div>
         </body>
       </html>`, nsResolver);
@@ -222,22 +222,22 @@ describe('native nodeset functions', () => {
     const doc = initDoc(`
       <!DOCTYPE html>
       <html xml:lang="en-us" xmlns="http://www.w3.org/1999/xhtml" xmlns:ev="http://some-namespace.com/nss">
-      	<head>
-      		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-      		<title>xpath-test</title>
-      	</head>
-      	<body class="yui3-skin-sam" id="body">
+        <head>
+          <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+          <title>xpath-test</title>
+        </head>
+        <body class="yui3-skin-sam" id="body">
           <div id="testFunctionNodeset">
-      			<div id="testFunctionNodesetElement">aaa</div>
-      			<div id="testFunctionNodesetElementPrefix"><ev:div2></ev:div2></div>
-      			<div id="testFunctionNodesetElementNested"><span>bbb</span>sss<span></span><div>ccc<span>ddd</span></div></div>
-      			<div id="testFunctionNodesetComment"><!-- hello world --></div>
-      			<div id="testFunctionNodesetText">here is some text</div>
-      			<div id="testFunctionNodesetProcessingInstruction"><?xml-stylesheet type="text/xml" href="test.xsl"?></div>
-      			<div id="testFunctionNodesetCData"><![CDATA[some cdata]]></div>
-      			<div id="testFunctionNodesetAttribute" ev:class="123" width="  1   00%  "></div>
-      			<div id="testFunctionNodesetNamespace" xmlns:asdf="http://www.123.com/"></div>
-      		</div>
+            <div id="testFunctionNodesetElement">aaa</div>
+            <div id="testFunctionNodesetElementPrefix"><ev:div2></ev:div2></div>
+            <div id="testFunctionNodesetElementNested"><span>bbb</span>sss<span></span><div>ccc<span>ddd</span></div></div>
+            <div id="testFunctionNodesetComment"><!-- hello world --></div>
+            <div id="testFunctionNodesetText">here is some text</div>
+            <div id="testFunctionNodesetProcessingInstruction"><?xml-stylesheet type="text/xml" href="test.xsl"?></div>
+            <div id="testFunctionNodesetCData"><![CDATA[some cdata]]></div>
+            <div id="testFunctionNodesetAttribute" ev:class="123" width="  1   00%  "></div>
+            <div id="testFunctionNodesetNamespace" xmlns:asdf="http://www.123.com/"></div>
+          </div>
         </body>
       </html>`, nsResolver);
 
@@ -303,22 +303,22 @@ describe('native nodeset functions', () => {
     const doc = initDoc(`
       <!DOCTYPE html>
       <html xml:lang="en-us" xmlns="http://www.w3.org/1999/xhtml" xmlns:ev="http://some-namespace.com/nss">
-      	<head>
-      		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-      		<title>xpath-test</title>
-      	</head>
-      	<body class="yui3-skin-sam" id="body">
+        <head>
+          <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+          <title>xpath-test</title>
+        </head>
+        <body class="yui3-skin-sam" id="body">
           <div id="testFunctionNodeset">
-      			<div id="testFunctionNodesetElement">aaa</div>
-      			<div id="testFunctionNodesetElementPrefix"><ev:div2></ev:div2></div>
-      			<div id="testFunctionNodesetElementNested"><span>bbb</span>sss<span></span><div>ccc<span>ddd</span></div></div>
-      			<div id="testFunctionNodesetComment"><!-- hello world --></div>
-      			<div id="testFunctionNodesetText">here is some text</div>
-      			<div id="testFunctionNodesetProcessingInstruction"><?xml-stylesheet type="text/xml" href="test.xsl"?></div>
-      			<div id="testFunctionNodesetCData"><![CDATA[some cdata]]></div>
-      			<div id="testFunctionNodesetAttribute" ev:class="123" width="  1   00%  "></div>
-      			<div id="testFunctionNodesetNamespace" xmlns:asdf="http://www.123.com/"></div>
-      		</div>
+            <div id="testFunctionNodesetElement">aaa</div>
+            <div id="testFunctionNodesetElementPrefix"><ev:div2></ev:div2></div>
+            <div id="testFunctionNodesetElementNested"><span>bbb</span>sss<span></span><div>ccc<span>ddd</span></div></div>
+            <div id="testFunctionNodesetComment"><!-- hello world --></div>
+            <div id="testFunctionNodesetText">here is some text</div>
+            <div id="testFunctionNodesetProcessingInstruction"><?xml-stylesheet type="text/xml" href="test.xsl"?></div>
+            <div id="testFunctionNodesetCData"><![CDATA[some cdata]]></div>
+            <div id="testFunctionNodesetAttribute" ev:class="123" width="  1   00%  "></div>
+            <div id="testFunctionNodesetNamespace" xmlns:asdf="http://www.123.com/"></div>
+          </div>
         </body>
       </html>`, nsResolver);
 

--- a/test/integration/native/number.spec.js
+++ b/test/integration/native/number.spec.js
@@ -45,24 +45,24 @@ describe('native number functions', () => {
     beforeEach(() => {
       doc = initDoc(`
         <div id="FunctionNumberCase">
-    			<div id="FunctionNumberCaseNumber">123</div>
-    			<div id="FunctionNumberCaseNotNumber">  a a  </div>
-    			<div id="FunctionNumberCaseNumberMultiple">
-    				<div>-10</div>
-    				<div>11</div>
-    				<div>99</div>
-    			</div>
-    			<div id="FunctionNumberCaseNotNumberMultiple">
-    				<div>-10</div>
-    				<div>11</div>
-    				<div>a</div>
-    			</div>
+          <div id="FunctionNumberCaseNumber">123</div>
+          <div id="FunctionNumberCaseNotNumber">  a a  </div>
+          <div id="FunctionNumberCaseNumberMultiple">
+            <div>-10</div>
+            <div>11</div>
+            <div>99</div>
+          </div>
+          <div id="FunctionNumberCaseNotNumberMultiple">
+            <div>-10</div>
+            <div>11</div>
+            <div>a</div>
+          </div>
           <div id="FunctionSumCaseJavarosa">
-      			<div>-10</div>
-      			<div>15</div>
-      			<div></div>
-      		</div>
-    		</div>`);
+            <div>-10</div>
+            <div>15</div>
+            <div></div>
+          </div>
+        </div>`);
     });
 
     it('number() ', () => {

--- a/test/integration/native/string.spec.js
+++ b/test/integration/native/string.spec.js
@@ -33,23 +33,23 @@ describe('native string functions', () => {
   it('string() conversion of nodesets', () => {
     const doc = initDoc(`
       <div id="FunctionStringCase">
-  			<div id="FunctionStringCaseStringNodesetElement">aaa</div>
-  			<div id="FunctionStringCaseStringNodesetElementNested"><span>bbb</span>sss<span></span><div>ccc<span>ddd</span></div></div>
-  			<div id="FunctionStringCaseStringNodesetComment"><!-- hello world --></div>
-  			<div id="FunctionStringCaseStringNodesetText">here is some text</div>
-  			<div id="FunctionStringCaseStringNodesetProcessingInstruction"><?xml-stylesheet type="text/xml" href="test.xsl"?></div>
-  			<div id="FunctionStringCaseStringNodesetCData"><![CDATA[some cdata]]></div>
-  			<div id="FunctionStringCaseStringNodesetAttribute" class="123" width="  1   00%  "></div>
-  			<div id="FunctionStringCaseStringNodesetNamespace" xmlns:asdf="http://www.123.com/"></div>
-  			<div id="FunctionStringCaseStringLength1"></div>
-  			<div id="FunctionStringCaseStringLength2">asdf</div>
-  			<div id="FunctionStringCaseStringNormalizeSpace1"></div>
-  			<div id="FunctionStringCaseStringNormalizeSpace2">   </div>
-  			<div id="FunctionStringCaseStringNormalizeSpace3">  a  b  </div>
-  			<div id="FunctionStringCaseStringNormalizeSpace4">  a
-  				 bc  c
-  			</div>
-  		</div>`);
+        <div id="FunctionStringCaseStringNodesetElement">aaa</div>
+        <div id="FunctionStringCaseStringNodesetElementNested"><span>bbb</span>sss<span></span><div>ccc<span>ddd</span></div></div>
+        <div id="FunctionStringCaseStringNodesetComment"><!-- hello world --></div>
+        <div id="FunctionStringCaseStringNodesetText">here is some text</div>
+        <div id="FunctionStringCaseStringNodesetProcessingInstruction"><?xml-stylesheet type="text/xml" href="test.xsl"?></div>
+        <div id="FunctionStringCaseStringNodesetCData"><![CDATA[some cdata]]></div>
+        <div id="FunctionStringCaseStringNodesetAttribute" class="123" width="  1   00%  "></div>
+        <div id="FunctionStringCaseStringNodesetNamespace" xmlns:asdf="http://www.123.com/"></div>
+        <div id="FunctionStringCaseStringLength1"></div>
+        <div id="FunctionStringCaseStringLength2">asdf</div>
+        <div id="FunctionStringCaseStringNormalizeSpace1"></div>
+        <div id="FunctionStringCaseStringNormalizeSpace2">   </div>
+        <div id="FunctionStringCaseStringNormalizeSpace3">  a  b  </div>
+        <div id="FunctionStringCaseStringNormalizeSpace4">  a
+           bc  c
+        </div>
+      </div>`);
     let input;
     let i;
     let node;
@@ -88,11 +88,11 @@ describe('native string functions', () => {
     const doc = initDoc(`
       <!DOCTYPE html>
       <html xml:lang="en-us" xmlns="http://www.w3.org/1999/xhtml" xmlns:ev="http://some-namespace.com/nss">
-      	<head>
-      		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-      		<title>xpath-test</title>
-      	</head>
-      	<body class="yui3-skin-sam" id="body">
+        <head>
+          <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+          <title>xpath-test</title>
+        </head>
+        <body class="yui3-skin-sam" id="body">
           <div id="FunctionStringCaseStringNodesetNamespace" xmlns:asdf="http://www.123.com/"></div>
         </body>
       </html>`);
@@ -218,7 +218,7 @@ describe('native string functions', () => {
     const doc = initDoc(`
       <div>
         <div id="FunctionStringCaseStringLength1"></div>
-  			<div id="FunctionStringCaseStringLength2">asdf</div>
+        <div id="FunctionStringCaseStringLength2">asdf</div>
       </div>`);
     [
       ["string-length('')", 0, doc],
@@ -240,11 +240,11 @@ describe('native string functions', () => {
     const doc = initDoc(`
       <div>
         <div id="FunctionStringCaseStringNormalizeSpace1"></div>
-  			<div id="FunctionStringCaseStringNormalizeSpace2">   </div>
-  			<div id="FunctionStringCaseStringNormalizeSpace3">  a  b  </div>
-  			<div id="FunctionStringCaseStringNormalizeSpace4">  a
-  				 bc  c
-  			</div>
+        <div id="FunctionStringCaseStringNormalizeSpace2">   </div>
+        <div id="FunctionStringCaseStringNormalizeSpace3">  a  b  </div>
+        <div id="FunctionStringCaseStringNormalizeSpace4">  a
+           bc  c
+        </div>
       </div>`);
     [
       ["normalize-space('')", '', doc],

--- a/test/integration/native/union-operator.spec.js
+++ b/test/integration/native/union-operator.spec.js
@@ -6,27 +6,27 @@ describe('Union operator', () => {
   beforeEach(() => {
     doc = initDoc(`
       <div id="UnionOperatorTestCase">
-  			<div id="eee10">
-  				<div id="eee20">
-  					<div>
-  						<div id="eee25"></div>
-  					</div>
-  				</div>
-  				<div id="eee30">
-  					<div id="eee35"></div>
-  					<div id="eee40" class="sss"></div>
-  				</div>
-  			</div>
-  			<div id="eee50"></div>
+        <div id="eee10">
+          <div id="eee20">
+            <div>
+              <div id="eee25"></div>
+            </div>
+          </div>
+          <div id="eee30">
+            <div id="eee35"></div>
+            <div id="eee40" class="sss"></div>
+          </div>
+        </div>
+        <div id="eee50"></div>
 
-  			<div id="nss10">
-  				<div id="nss20">
-  					<div id="nss25" xmlns:asdf="http://asdf.com/" align="right"></div>
-  					<div xmlns:asdf="http://asdf.com/" id="nss30"></div>
-  				</div>
-  				<div id="nss40" xmlns:asdf="sss" xmlns:asdf2="sdfsdf"></div>
-  			</div>
-  		</div>`);
+        <div id="nss10">
+          <div id="nss20">
+            <div id="nss25" xmlns:asdf="http://asdf.com/" align="right"></div>
+            <div xmlns:asdf="http://asdf.com/" id="nss30"></div>
+          </div>
+          <div id="nss40" xmlns:asdf="sss" xmlns:asdf2="sdfsdf"></div>
+        </div>
+      </div>`);
   });
 
   it('combines elements', () => {

--- a/test/integration/openrosa-xpath/concat.spec.js
+++ b/test/integration/openrosa-xpath/concat.spec.js
@@ -27,13 +27,13 @@ describe('#concat', () => {
   it('should concatenate nodeset', () => {
     const doc = initDoc(`
       <div id="testFunctionNodeset">
-			  <div id="testFunctionNodeset2">
-    			<p>1</p>
-    			<p>2</p>
-    			<p>3</p>
-    			<p>4</p>
-			  </div>
-			</div>`);
+        <div id="testFunctionNodeset2">
+          <p>1</p>
+          <p>2</p>
+          <p>3</p>
+          <p>4</p>
+        </div>
+      </div>`);
     const node = doc.getElementById('testFunctionNodeset2');
     assertStringValue(node, null, "concat(*, 'a')", '1234a');
     assertStringValue(node, null, "concat(*)", '1234');

--- a/test/integration/openrosa-xpath/count-non-empty.spec.js
+++ b/test/integration/openrosa-xpath/count-non-empty.spec.js
@@ -6,23 +6,23 @@ describe('count-non-empty', () => {
       <!DOCTYPE html>
       <html xml:lang="en-us" xmlns="http://www.w3.org/1999/xhtml" xmlns:ev="http://some-namespace.com/nss">
         <head>
-      		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-      		<title>xpath-test</title>
-      	</head>
-      	<body class="yui3-skin-sam" id="body">
+          <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+          <title>xpath-test</title>
+        </head>
+        <body class="yui3-skin-sam" id="body">
           <div id="FunctionCountNonEmpty">
-      			<div>-5</div>
-      			<div>-15</div>
-      			<div></div>
-      			<p>
-      				<div></div>
-      				<div><!--comment--></div>
-      				<span>  </span>
-      				<span>
-      				</span>
-      			</p>
-      			<p></p>
-  		     </div>
+            <div>-5</div>
+            <div>-15</div>
+            <div></div>
+            <p>
+              <div></div>
+              <div><!--comment--></div>
+              <span>  </span>
+              <span>
+              </span>
+            </p>
+            <p></p>
+           </div>
           </body>
         </html>`, nsResolver);
     assertNumberValue('count-non-empty(//xhtml:div[@id="FunctionCountNonEmpty"]/xhtml:div)', 2);

--- a/test/integration/openrosa-xpath/count-selected.spec.js
+++ b/test/integration/openrosa-xpath/count-selected.spec.js
@@ -4,11 +4,11 @@ describe('#count-selected()', () => {
   it('count-selected()', () => {
     const doc = initDoc(`
       <div id="FunctionSelectedCase">
-  			<div id="FunctionSelectedCaseEmpty"></div>
-  			<div id="FunctionSelectedCaseSingle">ab</div>
-  			<div id="FunctionSelectedCaseMultiple">ab cd ef gh</div>
-  			<div id="FunctionSelectedCaseMultiple">ij</div>
-  		</div>`);
+        <div id="FunctionSelectedCaseEmpty"></div>
+        <div id="FunctionSelectedCaseSingle">ab</div>
+        <div id="FunctionSelectedCaseMultiple">ab cd ef gh</div>
+        <div id="FunctionSelectedCaseMultiple">ij</div>
+      </div>`);
 
     let node = doc.getElementById('FunctionSelectedCaseEmpty');
     assertNumberValue(node, null, 'count-selected(self::node())', 0);

--- a/test/integration/openrosa-xpath/date.spec.js
+++ b/test/integration/openrosa-xpath/date.spec.js
@@ -138,12 +138,12 @@ describe('#date()', () => {
   it('for nodes (where the date datatype is guessed)', () => {
     const doc = initDoc(`
       <div id="FunctionDate">
-  			<div id="FunctionDateCase1">2012-07-23</div>
-  			<div id="FunctionDateCase2">2012-08-20T00:00:00.00+00:00</div>
-  			<div id="FunctionDateCase3">2012-08-08T00:00:00+00:00</div>
-  			<div id="FunctionDateCase4">2012-06-23</div>
-  			<div id="FunctionDateCase5">2012-08-08T06:07:08.123-07:00</div>
-  		</div>`, nsResolver);
+        <div id="FunctionDateCase1">2012-07-23</div>
+        <div id="FunctionDateCase2">2012-08-20T00:00:00.00+00:00</div>
+        <div id="FunctionDateCase3">2012-08-08T00:00:00+00:00</div>
+        <div id="FunctionDateCase4">2012-06-23</div>
+        <div id="FunctionDateCase5">2012-08-08T06:07:08.123-07:00</div>
+      </div>`, nsResolver);
     [
       [".", doc.getElementById("FunctionDateCase1"), 15544.29],
       [".", doc.getElementById("FunctionDateCase2"), 15572]
@@ -183,12 +183,12 @@ describe('#date()', () => {
   it('datestring comparisons (date detection)', () => {
     const doc = initDoc(`
       <div id="FunctionDate">
-  			<div id="FunctionDateCase1">2012-07-23</div>
-  			<div id="FunctionDateCase2">2012-08-20T00:00:00.00+00:00</div>
-  			<div id="FunctionDateCase3">2012-08-08T00:00:00+00:00</div>
-  			<div id="FunctionDateCase4">2012-06-23</div>
-  			<div id="FunctionDateCase5">2012-08-08T06:07:08.123-07:00</div>
-  		</div>`);
+        <div id="FunctionDateCase1">2012-07-23</div>
+        <div id="FunctionDateCase2">2012-08-20T00:00:00.00+00:00</div>
+        <div id="FunctionDateCase3">2012-08-08T00:00:00+00:00</div>
+        <div id="FunctionDateCase4">2012-06-23</div>
+        <div id="FunctionDateCase5">2012-08-08T06:07:08.123-07:00</div>
+      </div>`);
     [
       [". < date('2012-07-24')", doc.getElementById("FunctionDateCase1" ), true],
       //returns false if strings are compared but true if dates are compared
@@ -210,9 +210,9 @@ describe('#date()', () => {
         </head>
         <body>
           <div id="FunctionDate">
-      			<div id="FunctionDateCase1">2012-07-23</div>
+            <div id="FunctionDateCase1">2012-07-23</div>
             <div id="FunctionDateCase4">2012-06-23</div>
-      		</div>
+          </div>
         </body>
       </html>`, nsResolver);
     [

--- a/test/integration/openrosa-xpath/format-date.spec.js
+++ b/test/integration/openrosa-xpath/format-date.spec.js
@@ -5,12 +5,12 @@ describe('#format-date()', () => {
   it('format-date()', () => {
     const doc = initDoc(`
       <div id="FunctionDate">
-  			<div id="FunctionDateCase1">2012-07-23</div>
-  			<div id="FunctionDateCase2">2012-08-20T00:00:00.00+00:00</div>
-  			<div id="FunctionDateCase3">2012-08-08T00:00:00+00:00</div>
-  			<div id="FunctionDateCase4">2012-06-23</div>
-  			<div id="FunctionDateCase5">2012-08-08T06:07:08.123-07:00</div>
-  		</div>`);
+        <div id="FunctionDateCase1">2012-07-23</div>
+        <div id="FunctionDateCase2">2012-08-20T00:00:00.00+00:00</div>
+        <div id="FunctionDateCase3">2012-08-08T00:00:00+00:00</div>
+        <div id="FunctionDateCase4">2012-06-23</div>
+        <div id="FunctionDateCase5">2012-08-08T06:07:08.123-07:00</div>
+      </div>`);
     const date = new Date();
     [
       ['format-date(.,  "%Y/%n | %y/%m | %b" )', doc.getElementById('FunctionDateCase1'), '2012/7 | 12/07 | Jul'],

--- a/test/integration/openrosa-xpath/min.spec.js
+++ b/test/integration/openrosa-xpath/min.spec.js
@@ -54,19 +54,19 @@ describe('#min()', () => {
   it('min(self::*) & min(*)', () => {
     const doc = initDoc(`
       <div id="FunctionNumberCase">
-  			<div id="FunctionNumberCaseNumber">123</div>
-  			<div id="FunctionNumberCaseNotNumber">  a a  </div>
-  			<div id="FunctionNumberCaseNumberMultiple">
-  				<div>-10</div>
-  				<div>11</div>
-  				<div>99</div>
-  			</div>
-  			<div id="FunctionNumberCaseNotNumberMultiple">
-  				<div>-10</div>
-  				<div>11</div>
-  				<div>a</div>
-  			</div>
-  		</div>`);
+        <div id="FunctionNumberCaseNumber">123</div>
+        <div id="FunctionNumberCaseNotNumber">  a a  </div>
+        <div id="FunctionNumberCaseNumberMultiple">
+          <div>-10</div>
+          <div>11</div>
+          <div>99</div>
+        </div>
+        <div id="FunctionNumberCaseNotNumberMultiple">
+          <div>-10</div>
+          <div>11</div>
+          <div>a</div>
+        </div>
+      </div>`);
     let node = doc.getElementById('FunctionNumberCaseNumber');
     assertNumberValue(node, null, 'min(self::*)',  123);
 
@@ -78,26 +78,26 @@ describe('#min()', () => {
     const doc = initDoc(`
       <div>
         <div id="FunctionMinCase">
-    			<div>5</div>
-    			<div>0</div>
-    			<div>15</div>
-    			<div>10</div>
-  		  </div>
+          <div>5</div>
+          <div>0</div>
+          <div>15</div>
+          <div>10</div>
+        </div>
 
-    		<div id="FunctionMaxCase">
-    			<div>-5</div>
-    			<div>0</div>
-    			<div>-15</div>
-    			<div>-10</div>
-    		</div>
+        <div id="FunctionMaxCase">
+          <div>-5</div>
+          <div>0</div>
+          <div>-15</div>
+          <div>-10</div>
+        </div>
 
-    		<div id="FunctionMaxMinCaseEmpty"></div>
+        <div id="FunctionMaxMinCaseEmpty"></div>
 
-    		<div id="FunctionMaxMinWithEmpty">
-    			<div>-5</div>
-    			<div>-15</div>
-    			<div></div>
-    		</div>
+        <div id="FunctionMaxMinWithEmpty">
+          <div>-5</div>
+          <div>-15</div>
+          <div></div>
+        </div>
 
         <div id="FunctionNumberCase">
           <div id="FunctionNumberCaseNumber">123</div>

--- a/test/integration/openrosa-xpath/number.spec.js
+++ b/test/integration/openrosa-xpath/number.spec.js
@@ -89,19 +89,19 @@ describe('#number()', () => {
     it('number() conversion of nodesets', () => {
       const doc = initDoc(`
         <div id="FunctionNumberCase">
-    			<div id="FunctionNumberCaseNumber">123</div>
-    			<div id="FunctionNumberCaseNotNumber">  a a  </div>
-    			<div id="FunctionNumberCaseNumberMultiple">
-    				<div>-10</div>
-    				<div>11</div>
-    				<div>99</div>
-    			</div>
-    			<div id="FunctionNumberCaseNotNumberMultiple">
-    				<div>-10</div>
-    				<div>11</div>
-    				<div>a</div>
-    			</div>
-    		</div>`);
+          <div id="FunctionNumberCaseNumber">123</div>
+          <div id="FunctionNumberCaseNotNumber">  a a  </div>
+          <div id="FunctionNumberCaseNumberMultiple">
+            <div>-10</div>
+            <div>11</div>
+            <div>99</div>
+          </div>
+          <div id="FunctionNumberCaseNotNumberMultiple">
+            <div>-10</div>
+            <div>11</div>
+            <div>a</div>
+          </div>
+        </div>`);
 
       let node = doc.getElementById('FunctionNumberCaseNumber');
       assertNumberValue(node, null, 'number(self::node())', 123);

--- a/test/integration/openrosa-xpath/once.spec.js
+++ b/test/integration/openrosa-xpath/once.spec.js
@@ -5,11 +5,11 @@ describe('once()', () => {
   it('attempt to change value of empty node', () => {
     const doc = initDoc(`
       <div id="FunctionSelectedCase">
-  			<div id="FunctionSelectedCaseEmpty"></div>
-  			<div id="FunctionSelectedCaseSingle">ab</div>
-  			<div id="FunctionSelectedCaseMultiple">ab cd ef gh</div>
-  			<div id="FunctionSelectedCaseMultiple">ij</div>
-  		</div>`);
+        <div id="FunctionSelectedCaseEmpty"></div>
+        <div id="FunctionSelectedCaseSingle">ab</div>
+        <div id="FunctionSelectedCaseMultiple">ab cd ef gh</div>
+        <div id="FunctionSelectedCaseMultiple">ij</div>
+      </div>`);
 
     let node = doc.getElementById('FunctionSelectedCaseEmpty');
     assertStringValue(node, null, 'once("aa")', 'aa');

--- a/test/integration/openrosa-xpath/position.spec.js
+++ b/test/integration/openrosa-xpath/position.spec.js
@@ -6,30 +6,30 @@ describe('#position()', () => {
     const doc = initDoc(`
       <!DOCTYPE html>
       <html xml:lang="en-us" xmlns="http://www.w3.org/1999/xhtml" xmlns:ev="http://some-namespace.com/nss">
-      	<head>
-      		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-      		<title>xpath-test</title>
-      	</head>
-      	<body class="yui3-skin-sam" id="body">
+        <head>
+          <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+          <title>xpath-test</title>
+        </head>
+        <body class="yui3-skin-sam" id="body">
           <div id="node1"/>
           <div id="node2"/>
           <div id="node3"/>
           <div id="node4"/>
           <div id="node5"/>
           <div id="FunctionNumberCase">
-      			<div id="FunctionNumberCaseNumber">123</div>
-      			<div id="FunctionNumberCaseNotNumber">  a a  </div>
-      			<div id="FunctionNumberCaseNumberMultiple">
-      				<div>-10</div>
-      				<div>11</div>
-      				<div>99</div>
-      			</div>
-      			<div id="FunctionNumberCaseNotNumberMultiple">
-      				<div>-10</div>
-      				<div>11</div>
-      				<div>a</div>
-      			</div>
-      		</div>
+            <div id="FunctionNumberCaseNumber">123</div>
+            <div id="FunctionNumberCaseNotNumber">  a a  </div>
+            <div id="FunctionNumberCaseNumberMultiple">
+              <div>-10</div>
+              <div>11</div>
+              <div>99</div>
+            </div>
+            <div id="FunctionNumberCaseNotNumberMultiple">
+              <div>-10</div>
+              <div>11</div>
+              <div>a</div>
+            </div>
+          </div>
         </body>
       </html>`);
 

--- a/test/integration/openrosa-xpath/randomize.spec.js
+++ b/test/integration/openrosa-xpath/randomize.spec.js
@@ -11,19 +11,19 @@ describe('randomize()', () => {
       doc = initDoc(`
         <!DOCTYPE html>
         <html xml:lang="en-us" xmlns="http://www.w3.org/1999/xhtml" xmlns:ev="http://some-namespace.com/nss">
-        	<head>
-        		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-        		<title>xpath-test</title>
-        	</head>
-        	<body class="yui3-skin-sam" id="body">
+          <head>
+            <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+            <title>xpath-test</title>
+          </head>
+          <body class="yui3-skin-sam" id="body">
             <div id="FunctionRandomize">
-        			<div>A</div>
-        			<div>B</div>
-        			<div>C</div>
-        			<div>D</div>
-        			<div>E</div>
-        			<div>F</div>
-        		</div>
+              <div>A</div>
+              <div>B</div>
+              <div>C</div>
+              <div>D</div>
+              <div>E</div>
+              <div>F</div>
+            </div>
             <div id="testFunctionNodeset2">
               <p>1</p>
               <p>2</p>

--- a/test/integration/openrosa-xpath/selected-at.spec.js
+++ b/test/integration/openrosa-xpath/selected-at.spec.js
@@ -22,17 +22,17 @@ describe('#selected-at()', () => {
     const doc = initDoc(`
       <!DOCTYPE html>
       <html xml:lang="en-us" xmlns="http://www.w3.org/1999/xhtml" xmlns:ev="http://some-namespace.com/nss">
-      	<head>
-      		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-      		<title>xpath-test</title>
-      	</head>
-      	<body class="yui3-skin-sam" id="body">
+        <head>
+          <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+          <title>xpath-test</title>
+        </head>
+        <body class="yui3-skin-sam" id="body">
           <div id="FunctionSelectedCase">
-      			<div id="FunctionSelectedCaseEmpty"></div>
-      			<div id="FunctionSelectedCaseSingle">ab</div>
-      			<div id="FunctionSelectedCaseMultiple">ab cd ef gh</div>
-      			<div id="FunctionSelectedCaseMultiple">ij</div>
-      		</div>
+            <div id="FunctionSelectedCaseEmpty"></div>
+            <div id="FunctionSelectedCaseSingle">ab</div>
+            <div id="FunctionSelectedCaseMultiple">ab cd ef gh</div>
+            <div id="FunctionSelectedCaseMultiple">ij</div>
+          </div>
         </body>
       </html>`);
     let node = doc.getElementById('FunctionSelectedCaseEmpty');

--- a/test/integration/openrosa-xpath/selected.spec.js
+++ b/test/integration/openrosa-xpath/selected.spec.js
@@ -35,18 +35,18 @@ describe('#selected()', () => {
     const doc = initDoc(`
       <!DOCTYPE html>
       <html xml:lang="en-us" xmlns="http://www.w3.org/1999/xhtml" xmlns:ev="http://some-namespace.com/nss">
-      	<head>
-      		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-      		<title>xpath-test</title>
-      	</head>
-      	<body class="yui3-skin-sam" id="body">
+        <head>
+          <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+          <title>xpath-test</title>
+        </head>
+        <body class="yui3-skin-sam" id="body">
           <div id="FunctionSelectedCase">
-      			<div id="FunctionSelectedCaseEmpty"></div>
-      			<div id="FunctionSelectedCaseSingle">ab</div>
-      			<div id="FunctionSelectedCaseMultiple">ab cd ef gh</div>
-      			<div id="FunctionSelectedCaseMultiple">ij</div>
-      		</div>
-      	</body>
+            <div id="FunctionSelectedCaseEmpty"></div>
+            <div id="FunctionSelectedCaseSingle">ab</div>
+            <div id="FunctionSelectedCaseMultiple">ab cd ef gh</div>
+            <div id="FunctionSelectedCaseMultiple">ij</div>
+          </div>
+        </body>
       </html>`);
     let node = doc.getElementById('FunctionSelectedCaseEmpty');
     assertTrue(node, null, 'selected(self::node(), "")');

--- a/test/integration/openrosa-xpath/sum.spec.js
+++ b/test/integration/openrosa-xpath/sum.spec.js
@@ -5,24 +5,24 @@ describe('#sum()', () => {
   it('sum(self::*)', () => {
     const doc = initDoc(`
       <div id="FunctionNumberCase">
-  			<div id="FunctionNumberCaseNumber">123</div>
-  			<div id="FunctionNumberCaseNotNumber">  a a  </div>
-  			<div id="FunctionNumberCaseNumberMultiple">
-  				<div>-10</div>
-  				<div>11</div>
-  				<div>99</div>
-  			</div>
-  			<div id="FunctionNumberCaseNotNumberMultiple">
-  				<div>-10</div>
-  				<div>11</div>
-  				<div>a</div>
-  			</div>
+        <div id="FunctionNumberCaseNumber">123</div>
+        <div id="FunctionNumberCaseNotNumber">  a a  </div>
+        <div id="FunctionNumberCaseNumberMultiple">
+          <div>-10</div>
+          <div>11</div>
+          <div>99</div>
+        </div>
+        <div id="FunctionNumberCaseNotNumberMultiple">
+          <div>-10</div>
+          <div>11</div>
+          <div>a</div>
+        </div>
         <div id="FunctionSumCaseJavarosa">
           <div>-10</div>
           <div>15</div>
           <div></div>
         </div>
-  		</div>`);
+      </div>`);
 
     let node = doc.getElementById('FunctionNumberCaseNumberMultiple');
     assertNumberValue(node, null, 'sum(*)', 100);

--- a/test/integration/openrosa-xpath/trigo.spec.js
+++ b/test/integration/openrosa-xpath/trigo.spec.js
@@ -11,15 +11,15 @@ describe('math functions', () => {
     initDoc(`
       <!DOCTYPE html>
       <html xml:lang="en-us" xmlns="http://www.w3.org/1999/xhtml" xmlns:ev="http://some-namespace.com/nss">
-      	<body class="yui3-skin-sam" id="body">
+        <body class="yui3-skin-sam" id="body">
           <div id="testFunctionNodeset">
-      			<div id="testFunctionNodeset2">
-      				<p>1</p>
-      				<p>2</p>
-      				<p>3</p>
-      				<p>4</p>
-      			</div>
-      		</div>
+            <div id="testFunctionNodeset2">
+              <p>1</p>
+              <p>2</p>
+              <p>3</p>
+              <p>4</p>
+            </div>
+          </div>
         </body>
       </html>`, nsResolver);
     assertNumberValue('sin(//xhtml:div[@id="testFunctionNodeset2"]/xhtml:p[2])', 0.9092974268256817);

--- a/test/integration/openrosa-xpath/weighted-checklist.spec.js
+++ b/test/integration/openrosa-xpath/weighted-checklist.spec.js
@@ -18,16 +18,16 @@ describe('#weighted-checklist()', () => {
     const doc = initDoc(`
       <root>
         <div id="FunctionChecklistCase">
-    			<div id="FunctionChecklistCaseNo">no</div>
-    			<div id="FunctionChecklistCaseEmpty"></div>
-    			<div id="FunctionChecklistCase0">0</div>
-    		</div>
+          <div id="FunctionChecklistCaseNo">no</div>
+          <div id="FunctionChecklistCaseEmpty"></div>
+          <div id="FunctionChecklistCase0">0</div>
+        </div>
 
-    		<div id="FunctionChecklistCaseValues">
-    			<div>1</div>
-    			<div>1</div>
-    			<div>5</div>
-    		</div>
+        <div id="FunctionChecklistCaseValues">
+          <div>1</div>
+          <div>1</div>
+          <div>5</div>
+        </div>
 
         <div id="FunctionWeightedChecklist">3</div>
       </root>`);


### PR DESCRIPTION
Please note, I've mixed this in with changing windows line endings to unix ones in `src/engine.js` to be consistent with the rest of the project.

Doing this as two separate PRs would be a bit of a headache, as fixing both the indentation and line-endings change every single line in that file.