### PR TITLE
Fix: use + for arithmetic only

### DIFF
--- a/src/utils/operation.js
+++ b/src/utils/operation.js
@@ -10,10 +10,27 @@ function isNumber(value) {
 }
 
 function handleOperation(lhs, op, rhs, config) {
-  //Removes quotes for numbers
-  if(op.v === '+' && isNumber(lhs.v) && isNumber(rhs.v)) {
-    lhs.v = Number(lhs.v);
-    rhs.v = Number(rhs.v);
+  //Removes quotes for numbers, detect and convert date/datetime strings
+  if(op.v === '+' ) {
+    // Operands will always be converted to numbers, no concatenation.
+    if (lhs.t === 'arr'){
+      // only take first of nodeset
+      lhs = {t: 'num', v: lhs.v[0]};
+    }
+    if (rhs.t === 'arr'){
+      // only take first of nodeset
+      rhs = {t: 'num', v: rhs.v[0]};
+    }
+    if (/^[0-9]{4}-[0-9]{2}-[0-9]{2}/.test(lhs.v)) {
+      lhs.v = dateToDays(lhs.v, false);
+    } else {
+      lhs.v = Number(lhs.v);
+    }
+    if (/^[0-9]{4}-[0-9]{2}-[0-9]{2}/.test(rhs.v)){
+      rhs.v = dateToDays(rhs.v, false);
+    } else {
+      rhs.v = Number(rhs.v);
+    }
   }
 
   //Comparing node expressions with numbers/strings/etc

--- a/test/extended-xpath.spec.js
+++ b/test/extended-xpath.spec.js
@@ -27,33 +27,21 @@ var docs = '',
       'concat("a", "b", "c")':
           /^abc$/,
       '"plus" + "one"':
-          /^plusone$/,
-      '"plus" + "one" + "plus" + "two"':
-          /^plusoneplustwo$/,
-      'upcase("what") + upcase("ever")':
-          /^WHATEVER$/,
-      'downcase("Fox"+"Trot")':
-          /^foxtrot$/,
-      'downcase("Fox" + "Trot")':
-          /^foxtrot$/,
+          /^NaN$/,
+      'upcase("what")':
+          /^WHAT$/,
       'concat(date())':
           new RegExp('^' + DATE_MATCH + '$'),
       'concat(date(), "X")':
           new RegExp('^' + DATE_MATCH + 'X$'),
       'concat("X", date())':
           new RegExp('^X' + DATE_MATCH + '$'),
-      '"Today\'s date: " + date()':
-          new RegExp('^Today\'s date: ' + DATE_MATCH + '$'),
-      'concat("Report::", "Today\'s date: " + date())':
+      'concat("Report::", "Today\'s date: ", date())':
           new RegExp('^Report::Today\'s date: ' + DATE_MATCH + '$'),
-      'concat(concat(upcase("Big") + downcase("Little")) + "Average", " by ", concat("Some", " ", "Author"))':
+      'concat(concat(upcase("Big"), downcase("Little")), "Average", " by ", concat("Some", " ", "Author"))':
           /^BIGlittleAverage by Some Author$/,
       '/xpath/expression':
           /^<xpath:\/xpath\/expression>$/,
-      '"string-prefix-" + /xpath/expression':
-          /^string-prefix-<xpath:\/xpath\/expression>$/,
-      '/xpath/expression + "-string-suffix"':
-          /^<xpath:\/xpath\/expression>-string-suffix$/,
       'concat("Evaluates to: ", /xpath/expression)':
           /^Evaluates to: <xpath:\/xpath\/expression>$/,
       '3':
@@ -76,10 +64,8 @@ var docs = '',
           /^(0\.0\d+)|(\d\.\d+e-\d)$/,
       '12 mod 5':
           /^2$/,
-      'reverse("hello " + "friend")':
-          /^dneirf olleh$/,
-      'reverse("hello ") + reverse("friend")':
-          /^ ollehdneirf$/,
+      'reverse("hello")':
+          /^olleh$/,
       'native_function()':
           /^<xpath:native_function\(\)>$/,
       'native_function(3)':
@@ -98,8 +84,11 @@ var docs = '',
           /^<xpath:native-function\("string-arg"\)>$/,
       'native-function(1, 2, 3, "a", \'b\', "c")':
           /^<xpath:native-function\(1, 2, 3, "a", "b", "c"\)>$/,
+      /* 
+      // Not clear what to do here as correcting this requires knowledge of return types of native functions.
       'native-function1(native-function2() + native-function3()) + native-function4(native-function5() + native-function6())':
           /^<xpath:native-function1\("<xpath:native-function2\(\)><xpath:native-function3\(\)>"\)><xpath:native-function4\("<xpath:native-function5\(\)><xpath:native-function6\(\)>"\)>$/,
+      */
       'native-function-with-space-before-bracket ()':
           /^<xpath:native-function-with-space-before-bracket\(\)>$/,
       '3 * 2 + 1':

--- a/test/integration/complex.spec.js
+++ b/test/integration/complex.spec.js
@@ -138,6 +138,7 @@ describe('some complex examples', () => {
     "(2+3)": 5,
     "2 + 3": 5,
     "(2 + 3)": 5,
+    "2 + 3": "5", // For some reason, it is evaluated correctly here.
     "today() < (today() + 1)": true,
     "today() > (today() + 1)": false,
     "today() < '1970-06-03'": false,

--- a/test/integration/infix-operators.spec.js
+++ b/test/integration/infix-operators.spec.js
@@ -1,4 +1,4 @@
-const {assertBoolean, assertString, assertNumberValue} = require('../helpers');
+const {assertBoolean, assertString, assertNumberValue, initDoc} = require('../helpers');
 
 describe('infix operators', () => {
   describe('math operators', () => {
@@ -195,6 +195,33 @@ describe('infix operators', () => {
 
       assertNumberValue('1-1', 0);
       assertNumberValue('1 - 1', 0);
+    });
+
+    it('calculation with node operand returned as string', () => {
+      var doc = initDoc(`
+      <data>
+        <number>4</number>
+      </data>`);
+
+      // It doesn't matter whether a string or number is requested, an infix operator should ensure that both 
+      // left and right operands are converted to numbers during evaluation.
+      // If multiple nodes are returned, the value of the first node will be used.
+      assertString('/data/number + 1', '5'); // returns '41'
+
+    });
+
+    it('calculation with multiple nodes operand returned as string', () => {
+      var doc = initDoc(`
+      <data>
+        <number>4</number>
+        <number>10</number>
+      </data>`);
+
+      // It doesn't matter whether a string or number is requested, an infix operator should ensure that both 
+      // left and right operands are converted to numbers during evaluation.
+      // If multiple nodes are returned, the value of the first node will be used.
+      assertString('/data/number + 1', '5'); // returns '4,101'
+
     });
   });
 });


### PR DESCRIPTION
Closes #31

Rebase of https://github.com/medic/openrosa-xpath-evaluator/pull/32 onto latest `medic/orxe2`.

@garethbowen as an aside, I don't know what the merge strategy is for this repo, but every time you merge a PR into the `medic/orxe2` branch, an extra commit is added in your name, but with no changes associated with it.  It seems to break e.g. `git show HEAD^`:

```
$ git log --pretty=oneline  | head -n5
7a0f14aa64593641b565db5e477c891d1865cf80 Remove non-number characters from 'num' support
cdbb00ecd53c7ef03517f92e049388273bfae92d Remove unused XPR type: nodes
667e7881012328c025890bff6f52b61926801109 Remove non-number characters from 'num' support
116500b3d7ec34d0145f531e8463685b39c9d68e Remove unused XPR type: nodes
0acb3fba6bb0c5f5ffc82ca76b5de0e279b6fc68 Replace inconsistent tab indentation with spaces

$ git show HEAD^^
commit 0acb3fba6bb0c5f5ffc82ca76b5de0e279b6fc68 (no-is-array)
Merge: bcf2ae8 0c7de49
Author: Gareth Bowen <gareth@medicmobile.org>
Date:   Tue Jun 9 09:36:42 2020 +1200

    Replace inconsistent tab indentation with spaces

```

I'd expect `git show HEAD^^` to be equivalent to `git show 116500b3d7ec34d0145f531e8463685b39c9d68e`, but maybe I'm just not used to how merge commits work :thinking: 