### PR TITLE
Reduce random test failures

### DIFF
--- a/test/integration/openrosa-xpath/random.spec.js
+++ b/test/integration/openrosa-xpath/random.spec.js
@@ -20,6 +20,6 @@ describe('#random()', () => {
   });
 
   it('random()', () => {
-    assert.match(doc.xEval('random()').numberValue, /0\.[0-9]{14,}/);
+    assert.match(doc.xEval('random()').numberValue, /0\.[0-9]{12,}/);
   });
 });


### PR DESCRIPTION
Currently the test at https://github.com/medic/openrosa-xpath-evaluator/blob/orxe2/test/integration/openrosa-xpath/random.spec.js#L22-L24 will fail ~1% of the time.  See e.g. https://travis-ci.org/github/medic/openrosa-xpath-evaluator/builds/698793824

Based on 10,000 iterations of the test in Chrome:

* reducing the expected decimal length to 13 reduces the failure rate to ~0.1%
* reducing the expected decimal length to 12 reduces the failure rate to ~0.01%

Without getting into a debate about the value of the tests in this file, this PR will reduce random test failures to near zero.