### PR TITLE
orxe2: replace tabs with spaces in src/engine.js

### DIFF
--- a/src/engine.js
+++ b/src/engine.js
@@ -32,71 +32,71 @@ module.exports = (function(){
     XPathEvaluator: OpenrosaXPathEvaluator,
 
     /**
-		 * Get the current list of DOM Level 3 XPath window and document objects
-		 * that are in use.
-		 *
-		 * @return {Object} List of DOM Level 3 XPath window and document objects
-		 *         that are currently in use.
-		 */
-		getCurrentDomLevel3XPathBindings: function()
-		{
-			return {
-				'window': {
-					XPathException: window.XPathException,
-					XPathExpression: window.XPathExpression,
-					XPathNSResolver: window.XPathNSResolver,
-					XPathResult: window.XPathResult,
-					XPathNamespace: window.XPathNamespace
-				},
-				'document': {
-					createExpression: document.createExpression,
-					createNSResolver: document.createNSResolver,
-					evaluate: document.evaluate
-				}
-			};
-		},
+     * Get the current list of DOM Level 3 XPath window and document objects
+     * that are in use.
+     *
+     * @return {Object} List of DOM Level 3 XPath window and document objects
+     *         that are currently in use.
+     */
+    getCurrentDomLevel3XPathBindings: function()
+    {
+      return {
+        'window': {
+          XPathException: window.XPathException,
+          XPathExpression: window.XPathExpression,
+          XPathNSResolver: window.XPathNSResolver,
+          XPathResult: window.XPathResult,
+          XPathNamespace: window.XPathNamespace
+        },
+        'document': {
+          createExpression: document.createExpression,
+          createNSResolver: document.createNSResolver,
+          evaluate: document.evaluate
+        }
+      };
+    },
 
-		/**
-		 * Get the list of DOM Level 3 XPath objects that are implemented by
-		 * the XPathJS module.
-		 *
-		 * @return {Object} List of DOM Level 3 XPath objects implemented by
-		 *         the XPathJS module.
-		 */
-		createDomLevel3XPathBindings: function(options)
-		{
+    /**
+     * Get the list of DOM Level 3 XPath objects that are implemented by
+     * the XPathJS module.
+     *
+     * @return {Object} List of DOM Level 3 XPath objects implemented by
+     *         the XPathJS module.
+     */
+    createDomLevel3XPathBindings: function(options)
+    {
       var openrosaEvaluator = new OpenrosaXPathEvaluator(options);
 
-			return {
-				'document': {
+      return {
+        'document': {
           evaluate: openrosaEvaluator.evaluate
-				}
-			};
-		},
+        }
+      };
+    },
 
-		/**
-		 * Bind DOM Level 3 XPath interfaces to the DOM.
-		 *
-		 * @param {Object} doc the document or (Document.prototype!) to bind the evaluator etc. to
-		 * @return List of original DOM Level 3 XPath objects that has been replaced
-		 */
-		bindDomLevel3XPath: function(doc, bindings)
-		{
-			var newBindings = (bindings || module.createDomLevel3XPathBindings()),
-				currentBindings = module.getCurrentDomLevel3XPathBindings(),
-				i
-			;
+    /**
+     * Bind DOM Level 3 XPath interfaces to the DOM.
+     *
+     * @param {Object} doc the document or (Document.prototype!) to bind the evaluator etc. to
+     * @return List of original DOM Level 3 XPath objects that has been replaced
+     */
+    bindDomLevel3XPath: function(doc, bindings)
+    {
+      var newBindings = (bindings || module.createDomLevel3XPathBindings()),
+        currentBindings = module.getCurrentDomLevel3XPathBindings(),
+        i
+      ;
 
-			doc = doc || document;
+      doc = doc || document;
 
-			for(i in newBindings['document'])
-			{
-				doc[i] = newBindings['document'][i];
-			}
+      for(i in newBindings['document'])
+      {
+        doc[i] = newBindings['document'][i];
+      }
 
-			return currentBindings;
-		}
+      return currentBindings;
+    }
   };
-	return module;
+  return module;
 
 })();


### PR DESCRIPTION
Looks like I messed up in https://github.com/medic/openrosa-xpath-evaluator/pull/38 - the second commit to remove Windows line-endings from `src/engine.js` re-introduced tabs :disappointed: 